### PR TITLE
Update smbclient.py

### DIFF
--- a/smbclient.py
+++ b/smbclient.py
@@ -109,7 +109,7 @@ class SambaClient(object):
              domain=None, resolve_order=None, port=None, ip=None,
              terminal_code=None, buffer_size=None, debug_level=None,
              config_file=None, logdir=None, netbios_name=None, kerberos=False,
-             runcmd_attemps=1):
+             runcmd_attemps=1, maxprotocol=None):
         self.path = '//%s/%s' % (server, share)
         smbclient_cmd = ['smbclient', self.path]
         self.debug_level = 0
@@ -118,6 +118,8 @@ class SambaClient(object):
         self._kerberos = kerberos
         if kerberos:
             smbclient_cmd.append('-k')
+        if maxprotocol:
+            smbclient_cmd.extend(['-m', maxprotocol])
         if resolve_order:
             smbclient_cmd.extend(['-R', ' '.join(resolve_order)])
         if port:


### PR DESCRIPTION
Added -m option

-m|--max-protocol protocol
           This allows the user to select the highest SMB protocol level that smbclient will use to connect to the server. By default this is set to NT1, which is the highest available SMB1 protocol. To connect using SMB2 or SMB3 protocol, use the strings SMB2 or SMB3 respectively. Note that to connect to a Windows 2012 server with encrypted transport selecting a max-protocol of SMB3 is required.