### PR TITLE
appends line break to authentication file to fix password problem

### DIFF
--- a/smbclient.py
+++ b/smbclient.py
@@ -148,7 +148,7 @@ class SambaClient(object):
             fd, self.auth_filename = tempfile.mkstemp(prefix="smb.auth.")
             auth_file = os.fdopen(fd, 'w+b')
             auth_file.write('\n'.join('%s=%s' % (k, v)
-                for k, v in self.auth.iteritems()))
+                for k, v in self.auth.iteritems()) + '\n')
             auth_file.close()
             smbclient_cmd.extend(['-A', self.auth_filename])
         if netbios_name:


### PR DESCRIPTION
Environment:
Red Hat Enterprise Linux 7.2
Python 2.7.5


Error:
smbclient.SambaClientError: Error on u'smbclient //X.X.X.X/SHARE$ -d True -A /tmp/smb.auth.5E78g3 -c ls "/*"': u"debug_parse_params: unrecognized debug class name or format [True]\nEnter DOMAIN\\USER's password: \nsession setup failed: NT_STATUS_LOGON_FAILURE"

Suggestion of solution:
Hi, the temp file doesn't include line break after password. In this case, I put the line break as bellow:
+                for k, v in self.auth.iteritems()) + '\n')